### PR TITLE
Update Laminar dependency bounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,13 +32,13 @@ classifiers = [
 ]
 
 dependencies = [
-  "airflow-balancer>=0.7.7,<0.8",
-  "airflow-common>=0.7.7,<0.8",
-  "airflow-config>=1.11,<1.12",
-  "airflow-ha>=1.6.2,<1.7",
+  "airflow-balancer>=0.7.8,<0.8",
+  "airflow-common>=0.7.9,<0.8",
+  "airflow-config>=1.12,<1.13",
+  "airflow-ha>=1.6.3,<1.7",
   "airflow-priority>=1.6.1,<1.7",
-  "airflow-pydantic>=1.5.9,<1.6",
-  "airflow-supervisor>=1.10.2,<1.11",
+  "airflow-pydantic>=1.6.1,<1.7",
+  "airflow-supervisor>=1.10.3,<1.11",
   "supervisor-pydantic>=1.3.3,<1.5",
 ]
 


### PR DESCRIPTION
Update the umbrella package to the released Airflow 3-compatible Laminar stack, including airflow-pydantic 1.6.1 and airflow-config 1.12.

This removes the old dependency generation that capped airflow-pydantic below 1.6.

Validated with a fresh resolution of all released dependencies, lint, and the package test suite.
